### PR TITLE
Cleanup on JSON for Media Grabber templates

### DIFF
--- a/templates.json
+++ b/templates.json
@@ -5438,7 +5438,6 @@
 					"name": "YTDL_PROXY"
 				},
 				{
-					"default": true,
 					"label": "YTDL_WRITEINFOJSON",
 					"name": "YTDL_WRITEINFOJSON",
 					"select": [
@@ -5454,7 +5453,6 @@
 					]
 				},
 				{
-					"default": false,
 					"label": "YTDL_VERBOSE",
 					"name": "YTDL_VERBOSE",
 					"select": [
@@ -5532,7 +5530,6 @@
 					"name": "YTDL_PROXY"
 				},
 				{
-					"default": true,
 					"label": "YTDL_WRITEINFOJSON",
 					"name": "YTDL_WRITEINFOJSON",
 					"select": [
@@ -5548,7 +5545,6 @@
 					]
 				},
 				{
-					"default": false,
 					"label": "YTDL_VERBOSE",
 					"name": "YTDL_VERBOSE",
 					"select": [

--- a/templates.json
+++ b/templates.json
@@ -5443,12 +5443,12 @@
 					"select": [
 						{
 							"text": "Enabled",
-							"value": true,
+							"value": "true",
 							"default": true
 						},
 						{
 							"text": "Disabled",
-							"value": false
+							"value": "false"
 						}
 					]
 				},
@@ -5458,12 +5458,12 @@
 					"select": [
 						{
 							"text": "Disabled",
-							"value": false,
+							"value": "false",
 							"default": true
 						},
 						{
 							"text": "Enabled",
-							"value": true
+							"value": "true"
 						}
 					]
 				},
@@ -5535,12 +5535,12 @@
 					"select": [
 						{
 							"text": "Enabled",
-							"value": true,
+							"value": "true",
 							"default": true
 						},
 						{
 							"text": "Disabled",
-							"value": false
+							"value": "false"
 						}
 					]
 				},
@@ -5550,12 +5550,12 @@
 					"select": [
 						{
 							"text": "Disabled",
-							"value": false,
+							"value": "false",
 							"default": true
 						},
 						{
 							"text": "Enabled",
-							"value": true
+							"value": "true"
 						}
 					]
 				},


### PR DESCRIPTION
The templates had slight issues in that they had `default` fields directly within the `env` fields which also had `select` definitions. The `select` fields define the default option used by marking one object within that array as having `"default": true`, negating the need for the `default` field above. In addition, the `value`s being used inside the `select` fields were bare booleans, which Portainer does not successfully parse in this context; it expects strings, even if they are the string representation of a bool.

Tested against Portainer CE 2.20.3. Note that the actual operation of these changes has not been tested (ie. if the templated container interprets the string argument properly); only that the template JSON definition is parsed and usable as is in Portainer. This is also a prerelease version of Portainer; however, the fixes are submitted now as they also work on 2.19.5 (currently tagged as latest).